### PR TITLE
Added Subject to Mail packet

### DIFF
--- a/models/protocols/SendGridProtocol.cfc
+++ b/models/protocols/SendGridProtocol.cfc
@@ -29,7 +29,9 @@ component extends="cbmailservices.models.AbstractProtocol" {
                 "email": mail.from
             }
         };
-
+        
+        body[ "subject" ] = mail.subject;
+        
         var personalization = {
             "to": [ {
                 "email": mail.to


### PR DESCRIPTION
Send grid will not send email without a Subject defined.