### PR TITLE
Add support for Categories

### DIFF
--- a/models/protocols/SendGridProtocol.cfc
+++ b/models/protocols/SendGridProtocol.cfc
@@ -33,6 +33,9 @@ component extends="cbmailservices.models.AbstractProtocol" {
         body[ "subject" ] = mail.subject;
         
         if( structKeyExists( mail, "additionalInfo" ) && isStruct( mail.additionalInfo ) && structKeyExists( mail.additionalInfo, "categories" ) ){
+            if ( ! isArray( mail.additionalInfo.categories ) ) {
+                mail.additionalInfo.categories = listToArray( mail.additionalInfo.categories );
+            }
             body[ "categories" ] = listToArray( mail.additionalInfo.categories );            
         }
         

--- a/models/protocols/SendGridProtocol.cfc
+++ b/models/protocols/SendGridProtocol.cfc
@@ -36,7 +36,7 @@ component extends="cbmailservices.models.AbstractProtocol" {
             if ( ! isArray( mail.additionalInfo.categories ) ) {
                 mail.additionalInfo.categories = listToArray( mail.additionalInfo.categories );
             }
-            body[ "categories" ] = listToArray( mail.additionalInfo.categories );            
+            body[ "categories" ] = mail.additionalInfo.categories;
         }
         
         var personalization = {

--- a/models/protocols/SendGridProtocol.cfc
+++ b/models/protocols/SendGridProtocol.cfc
@@ -32,6 +32,10 @@ component extends="cbmailservices.models.AbstractProtocol" {
         
         body[ "subject" ] = mail.subject;
         
+        if( structKeyExists( mail, "additionalInfo" ) && isStruct( mail.additionalInfo ) && structKeyExists( mail.additionalInfo, "categories" ) ){
+            body[ "categories" ] = listToArray( mail.additionalInfo.categories );            
+        }
+        
         var personalization = {
             "to": [ {
                 "email": mail.to


### PR DESCRIPTION
Send Grid allows for categories. This adds that support.
This change builds on top of a pull request for cbmailservices, which supports a struct for additionalInfo.
It does work without the cbmailservice update.