### PR TITLE
Adding support for dynamic_template_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /testbox/
 /modules/
+/.idea

--- a/models/protocols/SendGridProtocol.cfc
+++ b/models/protocols/SendGridProtocol.cfc
@@ -103,7 +103,7 @@ component extends="cbmailservices.models.AbstractProtocol" {
 
         if ( type == "template" ) {
             body[ "template_id" ] = mail.body;
-            personalization[ "substitutions" ] = mail.bodyTokens;
+            personalization[ "dynamic_template_data" ] = mail.bodyTokens;
         }
         else {
             body[ "content" ] = [ {


### PR DESCRIPTION
It does not appear that `substitutions` is valid when using dynamic templates with API v3. Moving the payload to `dynamic_template_data` resolved the issue.

Code change only affects emails where type is "template". All other functionality remains the same.